### PR TITLE
Update SCons to version 3.0.1

### DIFF
--- a/org.godotengine.Godot.json
+++ b/org.godotengine.Godot.json
@@ -24,8 +24,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://downloads.sourceforge.net/project/scons/scons/2.5.1/scons-2.5.1.tar.gz",
-                    "sha256": "0b25218ae7b46a967db42f2a53721645b3d42874a65f9552ad16ce26d30f51f2"
+                    "url": "https://downloads.sourceforge.net/project/scons/scons/3.0.1/scons-3.0.1.tar.gz",
+                    "sha256": "24475e38d39c19683bc88054524df018fe6949d70fbd4c69e298d39a0269f173"
                 }
             ],
             "build-commands": [ "python setup.py install --prefix=/app" ]


### PR DESCRIPTION
This updates SCons to the latest version. (By the way, as of 3.0, it is compatible with both Python 3 and Python 2.)