### PR TITLE
Update to 3.0.6

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -33,6 +33,6 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="3.0.5" date="2018-07-08"/>
+    <release version="3.0.6" date="2018-07-29"/>
   </releases>
 </component>

--- a/org.godotengine.Godot.json
+++ b/org.godotengine.Godot.json
@@ -37,8 +37,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/godotengine/godot/archive/3.0.5-stable.tar.gz",
-                    "sha256": "123723ebb6f59b2da00451963177309d0bc8c5cb4168e14f44dcbd00d4f12296"
+                    "url": "https://github.com/godotengine/godot/archive/3.0.6-stable.tar.gz",
+                    "sha256": "50431e021ee5ec21002cc23435f530f8fde518c6eb7085c9f7f1027abaae2581"
                 }
             ],
             "build-commands": [
@@ -77,8 +77,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/godotengine/godot/archive/3.0.5-stable.tar.gz",
-                    "sha256": "123723ebb6f59b2da00451963177309d0bc8c5cb4168e14f44dcbd00d4f12296"
+                    "url": "https://github.com/godotengine/godot/archive/3.0.6-stable.tar.gz",
+                    "sha256": "50431e021ee5ec21002cc23435f530f8fde518c6eb7085c9f7f1027abaae2581"
                 }
             ],
             "build-commands": [


### PR DESCRIPTION
This updates to the latest upstream version. Note that this does not include AppStream file updates as they were not merged in time for 3.0.6. However, they should be available for 3.0.7.