### PR TITLE
Build with link-time optimization enabled for better performance

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -6,6 +6,13 @@ sdk: org.freedesktop.Sdk
 command: godot
 
 build-options:
+  arch:
+    x86_64:
+      env:
+        # Only enable link-time optimization when targeting x86_64
+        # (causes issues on other architectures)
+        SCONS_FLAGS_EXTRA: use_lto=yes
+
   env:
     # Will be appended to the version string displayed in the editor and command-line help
     BUILD_NAME: flathub
@@ -18,7 +25,6 @@ build-options:
       prefix=/app
       unix_global_settings_path=/app
       progress=no
-      use_llvm=yes
       builtin_freetype=no
       builtin_libogg=no
       builtin_libpng=no
@@ -71,8 +77,8 @@ modules:
         path: org.godotengine.Godot.appdata.xml
 
     build-commands:
-      - scons $SCONS_FLAGS tools=yes target=release_debug -j "$FLATPAK_BUILDER_N_JOBS"
-      - install -D -m755 bin/godot.x11.opt.tools.*.llvm /app/bin/godot-bin
+      - scons $SCONS_FLAGS $SCONS_FLAGS_EXTRA tools=yes target=release_debug -j "$FLATPAK_BUILDER_N_JOBS"
+      - install -D -m755 bin/godot.x11.opt.tools.* /app/bin/godot-bin
       - install -D -m755 godot.sh /app/bin/godot
       - desktop-file-edit --set-icon=org.godotengine.Godot misc/dist/linux/org.godotengine.Godot.desktop
       - install -Dm644 misc/dist/linux/org.godotengine.Godot.desktop /app/share/applications/org.godotengine.Godot.desktop
@@ -99,5 +105,5 @@ modules:
         only-arches: [i386]
 
     build-commands:
-      - scons $SCONS_FLAGS tools=no target=release -j "$FLATPAK_BUILDER_N_JOBS"
-      - install -D -m755 bin/godot.x11.opt.*.llvm "/app/templates/linux_x11_$(getconf LONG_BIT)_release"
+      - scons $SCONS_FLAGS $SCONS_FLAGS_EXTRA tools=no target=release -j "$FLATPAK_BUILDER_N_JOBS"
+      - install -D -m755 bin/godot.x11.opt.* "/app/templates/linux_x11_$(getconf LONG_BIT)_release"


### PR DESCRIPTION
This also switches to GCC as compiler, as Godot's build system only supports enabling LTO with GCC.