### PR TITLE
Remove unused release template

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -91,19 +91,3 @@ modules:
           rsvg-convert icon.svg -w "$size" -h "$size" -a -f png -o "$size.png";
           install -Dm644 "$size.png" "/app/share/icons/hicolor/${size}x${size}/apps/org.godotengine.Godot.png";
         done
-
-  - name: godot-release-template
-    buildsystem: simple
-
-    sources:
-      - type: archive
-        sha256: a21ba76e504ef3840b0dca4a7dcd1e184ed49aec28356a68d8975700a0d90a25
-        url: https://downloads.tuxfamily.org/godotengine/3.1.1/godot-3.1.1-stable.tar.xz
-
-      - type: patch
-        path: godot-i386-disable-O3.patch
-        only-arches: [i386]
-
-    build-commands:
-      - scons $SCONS_FLAGS $SCONS_FLAGS_EXTRA tools=no target=release -j "$FLATPAK_BUILDER_N_JOBS"
-      - install -D -m755 bin/godot.x11.opt.* "/app/templates/linux_x11_$(getconf LONG_BIT)_release"


### PR DESCRIPTION
This makes the Flatpak smaller and build faster. A base application is in the works, so that projects using Godot can be easily packaged as Flatpaks.