### PR TITLE
Add wrapper scripts for adb and jarsigner

### DIFF
--- a/android-export-defaults.patch
+++ b/android-export-defaults.patch
@@ -1,0 +1,16 @@
+diff --git a/platform/android/export/export.cpp b/platform/android/export/export.cpp
+index e489bce3f..ed01ff928 100644
+--- a/platform/android/export/export.cpp
++++ b/platform/android/export/export.cpp
+@@ -1970,9 +1970,9 @@ void register_android_exporter() {
+ 		exe_ext = "*.exe";
+ 	}
+ 
+-	EDITOR_DEF("export/android/adb", "");
++	EDITOR_DEF("export/android/adb", "/app/bin/adb");
+ 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/adb", PROPERTY_HINT_GLOBAL_FILE, exe_ext));
+-	EDITOR_DEF("export/android/jarsigner", "");
++	EDITOR_DEF("export/android/jarsigner", "/app/bin/jarsigner");
+ 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/jarsigner", PROPERTY_HINT_GLOBAL_FILE, exe_ext));
+ 	EDITOR_DEF("export/android/debug_keystore", "");
+ 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/debug_keystore", PROPERTY_HINT_GLOBAL_FILE, "*.keystore"));

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -43,6 +43,7 @@ finish-args:
   - --socket=pulseaudio
   - --filesystem=host
   - --device=all
+  - --talk-name=org.freedesktop.Flatpak
 
 modules:
   - shared-modules/glu/glu-9.0.0.json
@@ -67,11 +68,24 @@ modules:
         sha256: a21ba76e504ef3840b0dca4a7dcd1e184ed49aec28356a68d8975700a0d90a25
         url: https://downloads.tuxfamily.org/godotengine/3.1.1/godot-3.1.1-stable.tar.xz
 
+      - type: patch
+        path: android-export-defaults.patch
+
       - type: script
         dest-filename: godot.sh
         commands:
           - export APPDATA="$XDG_DATA_HOME"
           - /app/bin/godot-bin "$@"
+
+      - type: script
+        dest-filename: adb.sh
+        commands:
+          - flatpak-spawn --host adb "$@"
+
+      - type: script
+        dest-filename: jarsigner.sh
+        commands:
+          - flatpak-spawn --host jarsigner "$@"
 
       - type: file
         path: org.godotengine.Godot.appdata.xml
@@ -80,6 +94,8 @@ modules:
       - scons $SCONS_FLAGS $SCONS_FLAGS_EXTRA tools=yes target=release_debug -j "$FLATPAK_BUILDER_N_JOBS"
       - install -D -m755 bin/godot.x11.opt.tools.* /app/bin/godot-bin
       - install -D -m755 godot.sh /app/bin/godot
+      - install -D -m755 adb.sh /app/bin/adb
+      - install -D -m755 jarsigner.sh /app/bin/jarsigner
       - desktop-file-edit --set-icon=org.godotengine.Godot misc/dist/linux/org.godotengine.Godot.desktop
       - install -Dm644 misc/dist/linux/org.godotengine.Godot.desktop /app/share/applications/org.godotengine.Godot.desktop
       - sed -i 's/<icon name="godot"/<icon name="org.godotengine.Godot"/' misc/dist/linux/x-godot-project.xml


### PR DESCRIPTION
This enables spawning host processes via flatpak-spawn by creating wrapper scripts in /app/bin and changes the default editor preference paths to the correct values.
Both utilities must be installed on the host and be accessible via PATH environment variable.

Closes flathub/org.godotengine.Godot#15
Closes godotengine/godot-website#60

http://docs.flatpak.org/en/latest/flatpak-command-reference.html#flatpak-spawn