### PR TITLE
Update Freedesktop runtime to 19.08

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -1,6 +1,6 @@
 app-id: org.godotengine.Godot
 runtime: org.freedesktop.Platform
-runtime-version: '18.08'
+runtime-version: '19.08'
 default-branch: stable
 sdk: org.freedesktop.Sdk
 command: godot
@@ -57,7 +57,7 @@ modules:
         url: https://downloads.sourceforge.net/project/scons/scons/3.1.1/scons-3.1.1.tar.gz
 
     build-commands:
-      - python setup.py install --prefix=/app
+      - python3 setup.py install --prefix=/app
 
   - name: godot-tools
     buildsystem: simple
@@ -77,7 +77,7 @@ modules:
         path: org.godotengine.Godot.appdata.xml
 
     build-commands:
-      - scons $SCONS_FLAGS $SCONS_FLAGS_EXTRA tools=yes target=release_debug -j "$FLATPAK_BUILDER_N_JOBS"
+      - python3 /app/bin/scons $SCONS_FLAGS $SCONS_FLAGS_EXTRA tools=yes target=release_debug -j "$FLATPAK_BUILDER_N_JOBS"
       - install -D -m755 bin/godot.x11.opt.tools.* /app/bin/godot-bin
       - install -D -m755 godot.sh /app/bin/godot
       - desktop-file-edit --set-icon=org.godotengine.Godot misc/dist/linux/org.godotengine.Godot.desktop


### PR DESCRIPTION
Python 2 was removed from the runtime, so the manifest was updated to use Python 3.