### PR TITLE
Fix the version being outdated in the AppStream metadata

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -34,6 +34,6 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
-    <release version="3.1" date="2019-03-14"/>
+    <release version="3.1.2" date="2019-11-29"/>
   </releases>
 </component>


### PR DESCRIPTION
This closes #48.

We should move to the [upstream-provided metadata](https://github.com/godotengine/godot/blob/master/misc/dist/linux/org.godotengine.Godot.appdata.xml) in the future, but it needs further tweaks before it can be used out of the box.