### PR TITLE
Use the `$FLATPAK_ID` environment variable to make code reuse easier

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -97,15 +97,15 @@ modules:
       - install -D -m755 adb.sh /app/bin/adb
       - install -D -m755 jarsigner.sh /app/bin/jarsigner
       # Remove the `PrefersNonDefaultGPU` key as it's not allowed by the `.desktop` file validator yet.
-      - desktop-file-edit --remove-key=PrefersNonDefaultGPU misc/dist/linux/org.godotengine.Godot.desktop
-      - desktop-file-edit --set-icon=org.godotengine.Godot misc/dist/linux/org.godotengine.Godot.desktop
-      - install -Dm644 misc/dist/linux/org.godotengine.Godot.desktop /app/share/applications/org.godotengine.Godot.desktop
-      - sed -i 's/<icon name="godot"/<icon name="org.godotengine.Godot"/' misc/dist/linux/x-godot-project.xml
-      - install -Dm644 misc/dist/linux/x-godot-project.xml /app/share/mime/packages/org.godotengine.Godot.xml
-      - install -Dm644 org.godotengine.Godot.appdata.xml /app/share/appdata/org.godotengine.Godot.appdata.xml
-      - install -Dm644 icon.svg /app/share/icons/hicolor/scalable/apps/org.godotengine.Godot.svg
+      - desktop-file-edit --remove-key=PrefersNonDefaultGPU misc/dist/linux/$FLATPAK_ID.desktop
+      - desktop-file-edit --set-icon=$FLATPAK_ID misc/dist/linux/$FLATPAK_ID.desktop
+      - install -Dm644 misc/dist/linux/$FLATPAK_ID.desktop /app/share/applications/$FLATPAK_ID.desktop
+      - sed -i 's/<icon name="godot"/<icon name="$FLATPAK_ID"/' misc/dist/linux/x-godot-project.xml
+      - install -Dm644 misc/dist/linux/x-godot-project.xml /app/share/mime/packages/$FLATPAK_ID.xml
+      - install -Dm644 $FLATPAK_ID.appdata.xml /app/share/appdata/$FLATPAK_ID.appdata.xml
+      - install -Dm644 icon.svg /app/share/icons/hicolor/scalable/apps/$FLATPAK_ID.svg
       - >
         for size in {32,64,128,256}; do
           rsvg-convert icon.svg -w "$size" -h "$size" -a -f png -o "$size.png";
-          install -Dm644 "$size.png" "/app/share/icons/hicolor/${size}x${size}/apps/org.godotengine.Godot.png";
+          install -Dm644 "$size.png" "/app/share/icons/hicolor/${size}x${size}/apps/$FLATPAK_ID.png";
         done


### PR DESCRIPTION
This makes it easier to copy-paste script lines between Flatpak manifests.