### PR TITLE
Disable exporting to Android as it doesn't work due to Flatpak sandboxing

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Exec Flags: --host code --reuse-window {project} --goto {file}:{line}:{col}
 
 - No C#/Mono support
   ([#8](https://github.com/flathub/org.godotengine.Godot/issues/8)).
+- No support for exporting to Android ([#63](https://github.com/flathub/org.godotengine.Godot/issues/63)).
+
+To bypass those limitations,
+[download a Godot build from godotengine.org](https://godotengine.org/download).
 
 ## Building from source
 

--- a/godot-disable-exporting-to-android.patch
+++ b/godot-disable-exporting-to-android.patch
@@ -1,0 +1,26 @@
+From 7eb3be3fa26456c5e28e91d295ebf5f6aa6897a5 Mon Sep 17 00:00:00 2001
+From: Hugo Locurcio <hugo.locurcio@hugo.pro>
+Date: Sun, 9 May 2021 20:18:22 +0200
+Subject: [PATCH] Disable exporting to Android as it doesn't work due to
+ Flatpak sandboxing
+
+---
+ platform/android/export/export.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/platform/android/export/export.cpp b/platform/android/export/export.cpp
+index 973f0febb8..e16f964935 100644
+--- a/platform/android/export/export.cpp
++++ b/platform/android/export/export.cpp
+@@ -2084,6 +2084,9 @@ public:
+ 		String err;
+ 		bool valid = false;
+
++		err = "The Flatpak build of Godot does not support exporting to Android. Download a Godot build from godotengine.org and try again.";
++		return valid;
++
+ 		// Look for export templates (first official, and if defined custom templates).
+
+ 		if (!bool(p_preset->get("custom_template/use_custom_build"))) {
+--
+2.30.2

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -68,6 +68,9 @@ modules:
         sha256: fcbbc6aaab16059e6622482c3358d58098d34ed51e099c854ec0ad79f466d555
         url: https://downloads.tuxfamily.org/godotengine/3.3/godot-3.3-stable.tar.xz
 
+      - type: patch
+        path: godot-disable-exporting-to-android.patch
+
       - type: script
         dest-filename: godot.sh
         commands:


### PR DESCRIPTION
See #63.

**Don't merge yet – it doesn't display any error message on screen.**