### PR TITLE
Update to FreeDesktop 21.08 runtime

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -1,6 +1,6 @@
 app-id: org.godotengine.Godot
 runtime: org.freedesktop.Platform
-runtime-version: '20.08'
+runtime-version: '21.08'
 default-branch: stable
 sdk: org.freedesktop.Sdk
 command: godot


### PR DESCRIPTION
This closes https://github.com/flathub/org.godotengine.Godot/issues/83.