### PR TITLE
Update Godot to 3.4

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -65,8 +65,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: 5261a8ad39c860c467f8b1bcede78252ff3e5a07b32fb24052ddfbb625aeb10f
-        url: https://downloads.tuxfamily.org/godotengine/3.4/rc3/godot-3.4-rc3.tar.xz
+        sha256: 1b01aa3cef9ac41c1033d0365c5e4ce74ea2d9547f333aa81804e60d33dfb4e6
+        url: https://downloads.tuxfamily.org/godotengine/3.4/godot-3.4-stable.tar.xz
 
       - type: script
         dest-filename: godot.sh


### PR DESCRIPTION
`beta` version of #89. This ensures the `beta` branch doesn't fall behind the stable branch.