### PR TITLE
Fix 3.4.1 reporting itself as `rc` instead of `stable`

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -65,7 +65,7 @@ modules:
 
     sources:
       - type: archive
-        sha256: f523f2435024dbe8a03a8b61871ca88a60861643550d45bc2d1ccf9ce3977fe1
+        sha256: e75549675c0a4faf01d60e0b7091be4bfcb4e3f261335fbc0d6a8e2f1d6988f9
         url: https://downloads.tuxfamily.org/godotengine/3.4.1/godot-3.4.1-stable.tar.xz
 
       - type: script


### PR DESCRIPTION
Editor version of https://github.com/flathub/org.godotengine.godot.BaseApp/pull/18.

This was due to an upstream packaging issue of the source tarball which is now fixed.

For the record, official Godot editor binaries were not affected by this bug.