### PR TITLE
Keep PrefersNonDefaultGPU in the `.desktop` file

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -81,8 +81,6 @@ modules:
       - python3 /app/bin/scons $SCONS_FLAGS $SCONS_FLAGS_EXTRA tools=yes target=release_debug -j "$FLATPAK_BUILDER_N_JOBS"
       - install -D -m755 bin/godot.x11.opt.tools.* /app/bin/godot-bin
       - install -D -m755 godot.sh /app/bin/godot
-      # Remove the `PrefersNonDefaultGPU` key as it's not allowed by the `.desktop` file validator yet.
-      - desktop-file-edit --remove-key=PrefersNonDefaultGPU misc/dist/linux/$FLATPAK_ID.desktop
       - desktop-file-edit --set-icon=$FLATPAK_ID misc/dist/linux/$FLATPAK_ID.desktop
       - install -Dm644 misc/dist/linux/$FLATPAK_ID.desktop /app/share/applications/$FLATPAK_ID.desktop
       - install -Dm644 misc/dist/linux/$FLATPAK_ID.xml /app/share/mime/packages/$FLATPAK_ID.xml


### PR DESCRIPTION
This makes Godot request the dedicated GPU when available to improve performance.