### PR TITLE
Fx Android Export

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -3,6 +3,7 @@ runtime: org.freedesktop.Platform
 runtime-version: '21.08'
 default-branch: stable
 sdk: org.freedesktop.Sdk
+sdk-extensions: [org.freedesktop.Sdk.Extension.openjdk11]
 command: godot
 
 build-options:
@@ -35,7 +36,6 @@ build-options:
       builtin_libvpx=no
       builtin_zlib=no
       udev=no
-
 finish-args:
   - --share=ipc
   - --socket=x11
@@ -47,6 +47,10 @@ finish-args:
 
 modules:
   - shared-modules/glu/glu-9.json
+
+  - name: openjdk
+    buildsystem: simple
+    build-commands: [/usr/lib/sdk/openjdk11/install.sh]
 
   - name: scons
     buildsystem: simple
@@ -72,6 +76,7 @@ modules:
         dest-filename: godot.sh
         commands:
           - export APPDATA="$XDG_DATA_HOME"
+          - export PATH="/app/jre/bin:$PATH"
           - /app/bin/godot-bin "$@"
 
       - type: file


### PR DESCRIPTION
Fixes android exports by adding the JRE as a dependency via SDK extensions.

This resolves the outstanding issue where Godot would call the native SDK folder's `apksigner` script which would, in turn, try and invoke Java but fail because it wasn't available in the sandbox.

![Fix](https://user-images.githubusercontent.com/15730577/161990401-a7d5ff6e-f953-4b28-86bb-74dc9c8b08df.png)

The Flatpak now relies on JRE11 as a dependency as a result (https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk11).

I have no certainty if appending to the path during application launch is the best approach for giving access to the local JRE on the environment path, so I'm open to alternative solutions. However, of all the approaches I tried while learning how Flatpaks are built, this is the only one that reliably works.