### PR TITLE
Update Godot to 3.5.0

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -46,6 +46,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="3.5.0" date="2022-08-06"/>
     <release version="3.4.4" date="2022-03-23"/>
     <release version="3.4.3" date="2022-02-25"/>
     <release version="3.4.2" date="2021-12-22"/>


### PR DESCRIPTION
This is the version used in the yaml spec since 2022-08-06, so this
should be reflected in the appdata.