### PR TITLE
Bump runtime to 22.08

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -1,6 +1,6 @@
 app-id: org.godotengine.Godot
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 default-branch: stable
 sdk: org.freedesktop.Sdk
 sdk-extensions:
@@ -64,7 +64,7 @@ modules:
         url: https://downloads.sourceforge.net/project/scons/scons/4.4.0/SCons-4.4.0.tar.gz
 
     build-commands:
-      - python3 setup.py install --prefix=/app
+      - pip3 install --no-index --no-build-isolation --prefix=/app .
 
   - name: godot-tools
     buildsystem: simple


### PR DESCRIPTION
Same as #110 but installs SCons using `pip install .` instead of `setup.py install`. Note that `--no-index` prevents pip from downloading packages from the internet, so this is still fully offline.

Using pip solves the `PackageNotFoundError` in #110 