### PR TITLE
Update README to include Blender information

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To use the built-in Blender importer, a script named `blender` should be placed 
 flatpak-spawn --host blender "$@"
 ```
 
-Then, configure the path to the Blender script in the Editor Settings (Filesystem > Import > Blender > Blender 3 Path).
+Then make the script executable using `chmod +x blender` and configure the path to the Blender script in the Editor Settings (**Filesystem > Import > Blender > Blender 3 Path**).
 
 ## Using an external script editor
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To use the built-in Blender importer, a script named `blender` should be placed 
 ```
 #!/bin/bash
 
-flatpak-spawn --host flatpak run org.blender.Blender "$@"
+flatpak-spawn --host blender "$@"
 ```
 
 Then, configure the path to the Blender script in the Editor Settings (Filesystem > Import > Blender > Blender 3 Path).

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ flatpak update
 
 This version of Godot is built with special [permissions](https://github.com/flathub/org.godotengine.Godot/blob/394f81c3310b82f5069ea917bb21f49888f818c6/org.godotengine.Godot.yaml#L46) to be able to run commands on the host system outside of the sandbox via [flatpak-spawn](https://docs.flatpak.org/en/latest/flatpak-command-reference.html#flatpak-spawn). This is done by prefixing the command with `flatpak-spawn --host`. For example, if you want to run `gnome-terminal` on the host system outside of the sandbox, you can do so by running `flatpak-spawn --host gnome-terminal`.
 
-To use the built-in Blender importer, a script named `blender` should be placed in a directory of your choosing and must contain the following contents:
+To use the built-in Blender importer, a script exactly named `blender` should be placed in a directory of your choosing and must contain the following contents:
 ```
 #!/bin/bash
 
 flatpak-spawn --host blender "$@"
 ```
 
-Then make the script executable using `chmod +x blender` and configure the path to the Blender script in the Editor Settings (**Filesystem > Import > Blender > Blender 3 Path**).
+Then make the script executable using `chmod +x blender` and configure the path to the directory containing the Blender script in the Editor Settings (**Filesystem > Import > Blender > Blender 3 Path**).
 
 ## Using an external script editor
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ flatpak update
 
 This version of Godot is built with special [permissions](https://github.com/flathub/org.godotengine.Godot/blob/394f81c3310b82f5069ea917bb21f49888f818c6/org.godotengine.Godot.yaml#L46) to be able to run commands on the host system outside of the sandbox via [flatpak-spawn](https://docs.flatpak.org/en/latest/flatpak-command-reference.html#flatpak-spawn). This is done by prefixing the command with `flatpak-spawn --host`. For example, if you want to run `gnome-terminal` on the host system outside of the sandbox, you can do so by running `flatpak-spawn --host gnome-terminal`.
 
-To use the built-in Blender importer, Godot expects the Blender executable to be named `blender`, lowercase and all. In order to use the importer in the flatpak, a script exactly named `blender` should be placed in a directory of your choosing and must contain the following contents:
+To use the built-in Blender importer, Godot expects the Blender executable to be named `blender` (lowercase). To use the importer in the Flatpak, a script exactly named `blender` should be placed in a directory of your choosing and must contain the following contents:
 ```
 #!/bin/bash
 

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ flatpak update
 
 This version of Godot is built with special [permissions](https://github.com/flathub/org.godotengine.Godot/blob/394f81c3310b82f5069ea917bb21f49888f818c6/org.godotengine.Godot.yaml#L46) to be able to run commands on the host system outside of the sandbox via [flatpak-spawn](https://docs.flatpak.org/en/latest/flatpak-command-reference.html#flatpak-spawn). This is done by prefixing the command with `flatpak-spawn --host`. For example, if you want to run `gnome-terminal` on the host system outside of the sandbox, you can do so by running `flatpak-spawn --host gnome-terminal`.
 
-To use the built-in Blender importer, a script exactly named `blender` should be placed in a directory of your choosing and must contain the following contents:
+To use the built-in Blender importer, Godot expects the Blender executable to be named `blender`, lowercase and all. In order to use the importer in the flatpak, a script exactly named `blender` should be placed in a directory of your choosing and must contain the following contents:
 ```
 #!/bin/bash
 
 flatpak-spawn --host blender "$@"
 ```
 
-Then make the script executable using `chmod +x blender` and configure the path to the directory containing the Blender script in the Editor Settings (**Filesystem > Import > Blender > Blender 3 Path**).
+Then make the script executable using `chmod +x blender` and configure the path to the directory containing the Blender script in the Editor Settings (**Filesystem > Import > Blender > Blender 3 Path**). 
 
 ## Using an external script editor
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,14 @@ flatpak update
 This version of Godot is built with special [permissions](https://github.com/flathub/org.godotengine.Godot/blob/394f81c3310b82f5069ea917bb21f49888f818c6/org.godotengine.Godot.yaml#L46) to be able to run commands on the host system outside of the sandbox via [flatpak-spawn](https://docs.flatpak.org/en/latest/flatpak-command-reference.html#flatpak-spawn). This is done by prefixing the command with `flatpak-spawn --host`. For example, if you want to run `gnome-terminal` on the host system outside of the sandbox, you can do so by running `flatpak-spawn --host gnome-terminal`.
 
 To use the built-in Blender importer, Godot expects the Blender executable to be named `blender` (lowercase). To use the importer in the Flatpak, a script exactly named `blender` should be placed in a directory of your choosing and must contain the following contents:
-```
+
+```bash
 #!/bin/bash
 
 flatpak-spawn --host blender "$@"
 ```
 
-Then make the script executable using `chmod +x blender` and configure the path to the directory containing the Blender script in the Editor Settings (**Filesystem > Import > Blender > Blender 3 Path**). 
+Then make the script executable using `chmod +x blender` and configure the path to the directory containing the Blender script in the Editor Settings (**Filesystem > Import > Blender > Blender 3 Path**).
 
 ## Using an external script editor
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ To update it, run the following command in a terminal:
 flatpak update
 ```
 
+## Using Blender
+
+This version of Godot is built with special [permissions](https://github.com/flathub/org.godotengine.Godot/blob/394f81c3310b82f5069ea917bb21f49888f818c6/org.godotengine.Godot.yaml#L46) to be able to run commands on the host system outside of the sandbox via [flatpak-spawn](https://docs.flatpak.org/en/latest/flatpak-command-reference.html#flatpak-spawn). This is done by prefixing the command with `flatpak-spawn --host`. For example, if you want to run `gnome-terminal` on the host system outside of the sandbox, you can do so by running `flatpak-spawn --host gnome-terminal`.
+
+To use the built-in Blender importer, a script named `blender` should be placed in a directory of your choosing and must contain the following contents:
+```
+#!/bin/bash
+
+flatpak-spawn --host flatpak run org.blender.Blender "$@"
+```
+
+Then, configure the path to the Blender script in the Editor Settings (Filesystem > Import > Blender > Blender 3 Path).
+
 ## Using an external script editor
 
 This version of Godot is built with special [permissions](https://github.com/flathub/org.godotengine.Godot/blob/394f81c3310b82f5069ea917bb21f49888f818c6/org.godotengine.Godot.yaml#L46) to be able to run commands on the host system outside of the sandbox via [flatpak-spawn](https://docs.flatpak.org/en/latest/flatpak-command-reference.html#flatpak-spawn). This is done by prefixing the command with `flatpak-spawn --host`. For example, if you want to run `gnome-terminal` on the host system outside of the sandbox, you can do so by running `flatpak-spawn --host gnome-terminal`.


### PR DESCRIPTION
While working on the proposal to select the Blender executable directly, I realized that since flatpak-spawn already runs, we can create a script that can run blender on the host. From my limited testing, it seems to work.