### PR TITLE
Update FreeDesktop SDK version to install for building in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ then enter the following commands in a terminal:
 ```bash
 git clone --recursive https://github.com/flathub/org.godotengine.Godot.git
 cd org.godotengine.Godot/
-flatpak install --user flathub org.freedesktop.Sdk//21.08 -y
+flatpak install --user flathub org.freedesktop.Sdk//22.08 -y
 flatpak-builder --force-clean --install --user -y builddir org.godotengine.Godot.yaml
 ```
 


### PR DESCRIPTION
This matches the Flatpak manifest.
