### PR TITLE
Update Godot to 4.0.1

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -46,6 +46,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="4.0.1" date="2023-03-20"/>
     <release version="4.0" date="2023-03-01"/>
     <release version="3.5.1" date="2022-09-28"/>
     <release version="3.5" date="2022-08-06"/>

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -73,8 +73,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: 8d92d2250176e2e5751e126ece72b78e6a124ee556111a8d8374c106e801b67f
-        url: https://downloads.tuxfamily.org/godotengine/4.0/godot-4.0-stable.tar.xz
+        sha256: 4a9725224f47cfb202d14ac5306eea475b2e4864780022a3df21d0cfffcd0fe1
+        url: https://downloads.tuxfamily.org/godotengine/4.0.1/godot-4.0.1-stable.tar.xz
 
       - type: script
         dest-filename: godot.sh


### PR DESCRIPTION
- Update release version on `org.godotengine.Godot.appdata.xml`.
- Update sha256 and source url to match the 4.0.1 release.