### PR TITLE
Update Godot to 4.1.1

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -46,6 +46,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="4.1.1" date="2023-07-17"/>
     <release version="4.1" date="2023-07-06"/>
     <release version="4.0.3" date="2023-05-19"/>
     <release version="4.0.2" date="2023-04-04"/>

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -73,8 +73,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: 5ef9a3b3591b1ceb2f89fba9419a05ef436d73514e2e15aebac4bebc246122ef
-        url: https://downloads.tuxfamily.org/godotengine/4.1/godot-4.1-stable.tar.xz
+        sha256: cd3cee1364020eb069f7cfdf2c484ba54fdeadc5a4d23fb9732d8e52923e1a71
+        url: https://github.com/godotengine/godot/releases/download/4.1.1-stable/godot-4.1.1-stable.tar.xz
 
       - type: script
         dest-filename: godot.sh


### PR DESCRIPTION
Using GitHub link to source download this time as it hasn't been uploaded to TuxFamily yet (I've no idea why). We can use the TuxFamily source download when it becomes available (or when the next Godot version is uploaded there).