### PR TITLE
Update Godot to 4.1.2

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -46,6 +46,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="4.1.2" date="2023-10-04"/>
     <release version="4.1.1" date="2023-07-17"/>
     <release version="4.1" date="2023-07-06"/>
     <release version="4.0.3" date="2023-05-19"/>

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -73,8 +73,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: cd3cee1364020eb069f7cfdf2c484ba54fdeadc5a4d23fb9732d8e52923e1a71
-        url: https://github.com/godotengine/godot/releases/download/4.1.1-stable/godot-4.1.1-stable.tar.xz
+        sha256: 41c9aedf1de788bd8e6c16bbb7a75411fde48023b54a8abbd936df47879d0108
+        url: https://downloads.tuxfamily.org/godotengine/4.1.2/godot-4.1.2-stable.tar.xz
 
       - type: script
         dest-filename: godot.sh


### PR DESCRIPTION
Since it looks like Godot releases will still be hosted on TuxFamily, as well as GitHub, I'm using the TuxFamily link for the Godot source file here (and for future releases too).