### PR TITLE
Update Godot to 4.2-dev6 for Flathub Beta

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -46,6 +46,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="4.2-dev6" date="2023-10-02"/>
     <release version="4.2-dev5" date="2023-09-19"/>
     <release version="4.2-dev4" date="2023-09-01"/>
     <release version="4.2-dev3" date="2023-08-10"/>

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -73,8 +73,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: 752b10a980aba6ec0aad67496e6a19004fddcc103a96266115ed9675847b2e24
-        url: https://downloads.tuxfamily.org/godotengine/4.2/dev5/godot-4.2-dev5.tar.xz
+        sha256: 11b54667ce776d922415242bb4af3b11d024682167fbe26fe13f8a49ddf4ac64
+        url: https://downloads.tuxfamily.org/godotengine/4.2/dev6/godot-4.2-dev6.tar.xz
 
       - type: script
         dest-filename: godot.sh


### PR DESCRIPTION
In [appdata.xml](https://github.com/Zishan-Rahman/org.godotengine.Godot/blob/693db5a9c326d4b796b564de4a2f9b11666132d7/org.godotengine.Godot.appdata.xml#L49), I used the TuxFamily publish date for 4.2-dev6's release date, because it was released a day before [the blog article on it](https://godotengine.org/article/dev-snapshot-godot-4-2-dev-6/) got published.