### PR TITLE
Update appdata.xml file with new links and other things 

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -35,15 +35,15 @@
   <url type="contribute">https://docs.godotengine.org/en/stable/contributing/ways_to_contribute.html</url>
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://godotengine.org/storage/app/media/3.0%20release/gltf.png</image>
+      <image type="source">https://github.com/godotengine/godot-website/blob/9a476ed665642572ecc4c54c0b3753f7e2b60b7f/storage/app/media/3.0%20release/gltf.png</image>
       <caption>Texture Viewer</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://godotengine.org/storage/blog/godot-4-0-sets-sail/08-editor-new-ui-editing-options.png</image>
+      <image type="source">https://github.com/godotengine/godot-website/blob/9a476ed665642572ecc4c54c0b3753f7e2b60b7f/storage/blog/godot-4-0-sets-sail/08-editor-new-ui-editing-options.png</image>
       <caption>Godot Editor (2D/UI view)</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://godotengine.org/storage/app/media/3.0%20release/particles.png</image>
+      <image type="source">https://github.com/godotengine/godot-website/blob/9a476ed665642572ecc4c54c0b3753f7e2b60b7f/storage/app/media/3.0%20release/particles.png</image>
       <caption>Particle Viewer</caption>
     </screenshot>
   </screenshots>

--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -35,15 +35,15 @@
   <url type="contribute">https://docs.godotengine.org/en/stable/contributing/ways_to_contribute.html</url>
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://godotengine.org/storage/app/media/3.0%20release/gltf.png</image>
+      <image>https://godotengine.org/storage/app/media/3.0%20release/gltf.png</image>
       <caption>Texture Viewer</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://docs.godotengine.org/en/stable/_images/editor_intro_workspace_2d.webp</image>
+      <image>https://docs.godotengine.org/en/stable/_images/editor_intro_workspace_2d.webp</image>
       <caption>Godot Editor (2D view)</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://godotengine.org/storage/app/media/3.0%20release/particles.png</image>
+      <image>https://godotengine.org/storage/app/media/3.0%20release/particles.png</image>
       <caption>Particle Viewer</caption>
     </screenshot>
   </screenshots>

--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -35,15 +35,15 @@
   <url type="contribute">https://docs.godotengine.org/en/stable/contributing/ways_to_contribute.html</url>
   <screenshots>
     <screenshot type="default">
-      <image>https://godotengine.org/storage/app/media/3.0%20release/gltf.png</image>
+      <image type="source">https://godotengine.org/storage/app/media/3.0%20release/gltf.png</image>
       <caption>Texture Viewer</caption>
     </screenshot>
     <screenshot>
-      <image>https://godotengine.org/storage/blog/godot-4-0-sets-sail/08-editor-new-ui-editing-options.png</image>
+      <image type="source">https://godotengine.org/storage/blog/godot-4-0-sets-sail/08-editor-new-ui-editing-options.png</image>
       <caption>Godot Editor (2D/UI view)</caption>
     </screenshot>
     <screenshot>
-      <image>https://godotengine.org/storage/app/media/3.0%20release/particles.png</image>
+      <image type="source">https://godotengine.org/storage/app/media/3.0%20release/particles.png</image>
       <caption>Particle Viewer</caption>
     </screenshot>
   </screenshots>

--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -3,6 +3,7 @@
   <id>org.godotengine.Godot.desktop</id>
   <name>Godot</name>
   <summary>Godot game engine editor</summary>
+  <developer_name>Godot Foundation</developer_name>
   <description>
     <p>Godot is an advanced, feature-packed, multi-platform 2D and 3D open source game engine.</p>
     <p>Create games with ease, using Godot's unique approach to game development.</p>
@@ -17,9 +18,8 @@
     <p>Limitations of the Flatpak version:</p>
     <ul>
       <li>No C#/Mono support. See: https://github.com/flathub/org.godotengine.Godot/issues/8</li>
-      <li>Custom builds for Android don't work. See: https://github.com/flathub/org.godotengine.Godot/issues/63</li>
-      <li>The old-fashioned way of exporting to Android still works: https://docs.godotengine.org/en/latest/tutorials/export/exporting_for_android.html</li>
       <li>External script editors are supported, but you need to follow the steps described here: https://github.com/flathub/org.godotengine.Godot#using-an-external-script-editor</li>
+      <li>Godot 4's Blender importer is supported, but Blender needs to be installed on your system and you need to follow the steps described here: https://github.com/flathub/org.godotengine.Godot#using-blender</li>
     </ul>
   </description>
   <metadata_license>CC0-1.0</metadata_license>
@@ -30,14 +30,17 @@
   <url type="help">https://docs.godotengine.org</url>
   <url type="donation">https://godotengine.org/donate</url>
   <url type="translate">https://hosted.weblate.org/projects/godot-engine/godot</url>
+  <url type="contact">https://godotengine.org/contact/</url>
+  <url type="vcs-browser">https://github.com/godotengine/godot</url>
+  <url type="contribute">https://docs.godotengine.org/en/stable/contributing/ways_to_contribute.html</url>
   <screenshots>
     <screenshot type="default">
       <image type="source">https://godotengine.org/storage/app/media/3.0%20release/gltf.png</image>
       <caption>Texture Viewer</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://godotengine.org/storage/app/media/3.0%20release/visual_script.png</image>
-      <caption>Visual Scripting</caption>
+      <image type="source">https://docs.godotengine.org/en/stable/_images/editor_intro_workspace_2d.webp</image>
+      <caption>Godot Editor (2D view)</caption>
     </screenshot>
     <screenshot>
       <image type="source">https://godotengine.org/storage/app/media/3.0%20release/particles.png</image>

--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -39,8 +39,8 @@
       <caption>Texture Viewer</caption>
     </screenshot>
     <screenshot>
-      <image>https://docs.godotengine.org/en/stable/_images/editor_intro_workspace_2d.webp</image>
-      <caption>Godot Editor (2D view)</caption>
+      <image>https://godotengine.org/storage/blog/godot-4-0-sets-sail/08-editor-new-ui-editing-options.png</image>
+      <caption>Godot Editor (2D/UI view)</caption>
     </screenshot>
     <screenshot>
       <image>https://godotengine.org/storage/app/media/3.0%20release/particles.png</image>

--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -3,7 +3,7 @@
   <id>org.godotengine.Godot.desktop</id>
   <name>Godot</name>
   <summary>Godot game engine editor</summary>
-  <developer_name>Juan Linietsky, Ariel Manzur and contributors</developer_name>
+  <developer_name>The Godot Engine Community</developer_name>
   <description>
     <p>Godot is an advanced, feature-packed, multi-platform 2D and 3D open source game engine.</p>
     <p>Create games with ease, using Godot's unique approach to game development.</p>

--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -3,7 +3,7 @@
   <id>org.godotengine.Godot.desktop</id>
   <name>Godot</name>
   <summary>Godot game engine editor</summary>
-  <developer_name>Godot Foundation</developer_name>
+  <developer_name>Juan Linietsky, Ariel Manzur and contributors</developer_name>
   <description>
     <p>Godot is an advanced, feature-packed, multi-platform 2D and 3D open source game engine.</p>
     <p>Create games with ease, using Godot's unique approach to game development.</p>


### PR DESCRIPTION
- Re-add developer name in different placement in appdata.xml ("The Godot Engine Community")
- Add additional line to unordered list about Blender importer (with link to README.md on Flatpak manifest's GitHub)
- Add more URLs (contact information, source code link and webpage on how to contribute back to Godot)
- Replace visual scripting screenshot with 2D editor screenshot (as visual scripting was removed from core engine from 4.0 onwards)
- Remove outdated bullet points from list about Android export failing (as this has already been taken care of in #100)