### PR TITLE
Update Godot to 4.2-beta2 for Flathub Beta

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -46,6 +46,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="4.2-beta2" date="2023-10-19"/>
     <release version="4.2-beta1" date="2023-10-12"/>
     <release version="4.1.1" date="2023-07-17"/>
     <release version="4.1" date="2023-07-06"/>

--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -46,6 +46,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="4.2-beta1" date="2023-10-12"/>
     <release version="4.2-dev6" date="2023-10-02"/>
     <release version="4.2-dev5" date="2023-09-19"/>
     <release version="4.2-dev4" date="2023-09-01"/>

--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -47,12 +47,6 @@
   <content_rating type="oars-1.1" />
   <releases>
     <release version="4.2-beta1" date="2023-10-12"/>
-    <release version="4.2-dev6" date="2023-10-02"/>
-    <release version="4.2-dev5" date="2023-09-19"/>
-    <release version="4.2-dev4" date="2023-09-01"/>
-    <release version="4.2-dev3" date="2023-08-10"/>
-    <release version="4.2-dev2" date="2023-07-28"/>
-    <release version="4.2-dev1" date="2023-07-19"/>
     <release version="4.1.1" date="2023-07-17"/>
     <release version="4.1" date="2023-07-06"/>
     <release version="4.0.3" date="2023-05-19"/>

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -73,8 +73,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: 11b54667ce776d922415242bb4af3b11d024682167fbe26fe13f8a49ddf4ac64
-        url: https://downloads.tuxfamily.org/godotengine/4.2/dev6/godot-4.2-dev6.tar.xz
+        sha256: 16897693d3b6ae5e68e8ab4522806fed785e1f2c8ce7e9925971bb3745afdd6b
+        url: https://github.com/godotengine/godot-builds/releases/download/4.2-beta1/godot-4.2-beta1.tar.xz
 
       - type: script
         dest-filename: godot.sh

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -73,8 +73,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: 16897693d3b6ae5e68e8ab4522806fed785e1f2c8ce7e9925971bb3745afdd6b
-        url: https://github.com/godotengine/godot-builds/releases/download/4.2-beta1/godot-4.2-beta1.tar.xz
+        sha256: a00d95dd52c88842204c88fbe9cd0ee2c7d6fc8cda1a9a1b8247b8a985a6481f
+        url: https://downloads.tuxfamily.org/godotengine/4.2/beta2/godot-4.2-beta2.tar.xz
 
       - type: script
         dest-filename: godot.sh


### PR DESCRIPTION
Should take the place of #136 now that [Godot 4.2 Beta 2](https://godotengine.org/article/dev-snapshot-godot-4-2-beta-2/) was just released.