### PR TITLE
Update Godot to 4.2-beta4 for Flathub Beta

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -46,6 +46,8 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="4.2-beta4" date="2023-10-31"/>
+    <release version="4.2-beta3" date="2023-10-24"/>
     <release version="4.2-beta2" date="2023-10-19"/>
     <release version="4.2-beta1" date="2023-10-12"/>
     <release version="4.1.1" date="2023-07-17"/>

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -73,8 +73,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: a00d95dd52c88842204c88fbe9cd0ee2c7d6fc8cda1a9a1b8247b8a985a6481f
-        url: https://downloads.tuxfamily.org/godotengine/4.2/beta2/godot-4.2-beta2.tar.xz
+        sha256: 0eee1face016be5db08a6a0035c6eef4160351cc811067d82208b0af66b5131f
+        url: https://github.com/godotengine/godot-builds/releases/download/4.2-beta4/godot-4.2-beta4.tar.xz
 
       - type: script
         dest-filename: godot.sh


### PR DESCRIPTION
Using GitHub releases download link this time around