### PR TITLE
Update Godot to 4.2 RC 2 for Flathub Beta

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -46,6 +46,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="4.2-rc2" date="2023-11-24"/>
     <release version="4.2-rc1" date="2023-11-17"/>
     <release version="4.1.1" date="2023-07-17"/>
     <release version="4.1" date="2023-07-06"/>

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -73,8 +73,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: ede6ac7812f13bca4c3f606f92ed45ba9cedc93f9007d5094d948a3adafc4d4f
-        url: https://downloads.tuxfamily.org/godotengine/4.2/rc1/godot-4.2-rc1.tar.xz
+        sha256: c3ad3e45a086b2de8ec514ca1278e5fd18022e5972eab24f809bc2af575dd61e
+        url: https://downloads.tuxfamily.org/godotengine/4.2/rc2/godot-4.2-rc2.tar.xz
 
       - type: script
         dest-filename: godot.sh


### PR DESCRIPTION
Using TuxFamily download link.

The blog post was published 1 day prior to the files getting uploaded to TuxFamily (they were presumably already uploaded to https://godotengine.org/download/archive/4.2-rc2/ on that day), hence that date being used instead of the 25th November 2023 date shown on the TuxFamily page.