### PR TITLE
Update Godot to 4.2.1 RC 1 for Flathub Beta

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -46,8 +46,8 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
-    <release version="4.2-rc2" date="2023-11-24"/>
-    <release version="4.2-rc1" date="2023-11-17"/>
+    <release version="4.2.1-rc1" date="2023-12-07"/>
+    <release version="4.2" date="2023-11-30"/>
     <release version="4.1.1" date="2023-07-17"/>
     <release version="4.1" date="2023-07-06"/>
     <release version="4.0.3" date="2023-05-19"/>

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -73,8 +73,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: c3ad3e45a086b2de8ec514ca1278e5fd18022e5972eab24f809bc2af575dd61e
-        url: https://downloads.tuxfamily.org/godotengine/4.2/rc2/godot-4.2-rc2.tar.xz
+        sha256: ebda42a64ff87f4825f0eccea98175470633123c69202a601b047762c98a0d58
+        url: https://downloads.tuxfamily.org/godotengine/4.2.1/rc1/godot-4.2.1-rc1.tar.xz
 
       - type: script
         dest-filename: godot.sh


### PR DESCRIPTION
Using TuxFamily download link, which was published 1 day prior to its corresponding article on the Godot blog.

Sorry for the lateness on my end.