### PR TITLE
Use Freedesktop SDK as runtime

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -1,10 +1,8 @@
 app-id: org.godotengine.Godot
-runtime: org.freedesktop.Platform
+runtime: org.freedesktop.Sdk
 runtime-version: '23.08'
 default-branch: stable
 sdk: org.freedesktop.Sdk
-sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk11
 command: godot
 
 build-options:
@@ -47,14 +45,10 @@ finish-args:
   - --filesystem=host
   - --device=all
   - --talk-name=org.freedesktop.Flatpak
+  - --env=JAVA_HOME=/usr/lib/sdk/openjdk17
 
 modules:
   - shared-modules/glu/glu-9.json
-
-  - name: openjdk
-    buildsystem: simple
-    build-commands:
-      - /usr/lib/sdk/openjdk11/install.sh
 
   - name: scons
     buildsystem: simple
@@ -80,7 +74,6 @@ modules:
         dest-filename: godot.sh
         commands:
           - export APPDATA="$XDG_DATA_HOME"
-          - export PATH="/app/jre/bin:$PATH"
           - /app/bin/godot-bin "$@"
 
       - type: file


### PR DESCRIPTION
- Setting runtime to `org.freedesktop.Sdk`, sandboxed Godot will be able to access SDK extensions through `/usr/lib/sdk`, without bundling JRE at build time.
- Set JAVA_HOME to use OpenJDK 17 for default , as stated in official Godot documentation.