### PR TITLE
Append java executables to PATH based on JAVA_HOME

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -74,6 +74,7 @@ modules:
         dest-filename: godot.sh
         commands:
           - export APPDATA="$XDG_DATA_HOME"
+          - if [ -f "$JAVA_HOME/enable.sh" ]; then source "$JAVA_HOME/enable.sh"; fi
           - /app/bin/godot-bin "$@"
 
       - type: file


### PR DESCRIPTION
When exporting to Android, package signing will fail if Java executables is not in `PATH`, even when `JAVA_HOME` is set. Exporting with `Use Gradle Build` enabled seems not affected by this.

This PR simply source the `enable.sh` provided by OpenJDK SDK extension that will append `$JAVA_HOME/bin` to `PATH` before running Godot editor. By locating the path based on `JAVA_HOME`, users can override the path if different OpenJDK version is installed.