### PR TITLE
Use Java from the official Freedesktop Sdk Extension

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -3,6 +3,8 @@ runtime: org.freedesktop.Sdk
 runtime-version: '23.08'
 default-branch: stable
 sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.openjdk17
 command: godot
 
 build-options:
@@ -45,10 +47,14 @@ finish-args:
   - --filesystem=host
   - --device=all
   - --talk-name=org.freedesktop.Flatpak
-  - --env=JAVA_HOME=/usr/lib/sdk/openjdk17
 
 modules:
   - shared-modules/glu/glu-9.json
+
+  - name: openjdk
+    buildsystem: simple
+    build-commands:
+      - /usr/lib/sdk/openjdk17/install.sh
 
   - name: scons
     buildsystem: simple
@@ -74,7 +80,7 @@ modules:
         dest-filename: godot.sh
         commands:
           - export APPDATA="$XDG_DATA_HOME"
-          - if [ -f "$JAVA_HOME/enable.sh" ]; then source "$JAVA_HOME/enable.sh"; fi
+          - export PATH="/app/jre/bin:$PATH"
           - /app/bin/godot-bin "$@"
 
       - type: file


### PR DESCRIPTION
#151 and #152 broke the build pipeline for Android by completely removing the Java Sdk Extension from the manifest and therefore Java from the build.

It was instead replaced by an environment variable JAVA_HOME pointing to a now non-existing directory ("/usr/lib/sdk/openjdk17", which is only accessible at build time or when running the flatpak with devel permissions), which caused the apksigner-step to fail with the message:

>  editor/export/editor_export_platform.h:179 - Code Signing: All 'apksigner' tools located in Android SDK 'build-tools' directory failed to execute. Please check that you have the correct version installed for your target sdk version. The resulting APK is unsigned.

See also godotengine/godot-docs#8742

This patch reverts to the old behaviour of installing the Freedesktop Sdk Extension and updates it from Version 11 to the recommended Version 17