### PR TITLE
Metainfo: Better align to other store listings

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -1,16 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <id>org.godotengine.Godot.desktop</id>
-  <name>Godot</name>
-  <summary>Godot game engine editor</summary>
+  <name>Godot Engine</name>
+  <summary>Easily create 2D and 3D games</summary>
   <developer_name>The Godot Engine Community</developer_name>
   <description>
-    <p>
-      <em>NOTE: This Flatpak is unofficial and not supported by Godot Engine developers.</em>
-      Find officially supported binaries on godotengine.org.
-    </p>
-    <p>Godot is an advanced, feature-packed, multi-platform 2D and 3D open source game engine.</p>
-    <p>Create games with ease, using Godot's unique approach to game development.</p>
+    <p>The feature-packed, cross-platform game engine to create 2D and 3D games from a unified interface. Godot Engine provides a comprehensive set of common tools, so that you can focus on making games without having to reinvent the wheel. Games can be exported in one click to a number of platforms, including the major desktop platforms (Linux, macOS, Windows) as well as mobile (Android, iOS), web-based (HTML5) platforms and consoles (Switch, PS4 and Xbox One - via thirdparty publishers).</p>
+    <p>Completely free and open source under the very permissive MIT license. No strings attached, no royalties, nothing. Your game is yours down to the last line of engine code. Godot's development is fully independent and community-driven, empowering you to help shape the engine to match your expectations. It is supported by the Software Freedom Conservancy not-for-profit.</p>
+    <p>Create games with ease, using Godot's unique approach to game development:</p>
     <ul>
       <li>Nodes for all your needs. Godot comes with hundreds of built-in nodes that make game design a breeze. You can also create your own for custom behaviors, editors and much more.</li>
       <li>Flexible scene system. Create node compositions with support for instancing and inheritance.</li>
@@ -19,7 +16,7 @@
       <li>Persistent live editing where changes are not lost after stopping the game. It even works on mobile devices!</li>
       <li>Create your own custom tools with ease using the incredible tool system.</li>
     </ul>
-    <p>Limitations of the Flatpak version:</p>
+    <p><em>NOTE: This Flatpak is unofficial and not supported by Godot Engine developers.</em> Find officially supported binaries on godotengine.org. Limitations of the Flatpak version:</p>
     <ul>
       <li>For C#/Mono support, install org.godotengine.GodotSharp instead: https://flathub.org/apps/org.godotengine.GodotSharp</li>
       <li>External script editors are supported, but you need to follow the steps described here: https://github.com/flathub/org.godotengine.Godot#using-an-external-script-editor</li>


### PR DESCRIPTION
This PR accomplishes a few things:
- Adapts the name and description to better match that used on [Itch](https://godotengine.itch.io/godot), [Steam](https://store.steampowered.com/app/404790/Godot_Engine/), and [Epic Games Store](https://store.epicgames.com/en-US/p/godot-engine) for consistency
- Better follow the [Flathub quality guidelines](https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/quality-guidelines) with the summary
- Groups the Flatpak caveats/limitations into one place (especially since Flathub doesn't support `<em>`, apparently, even though it's in [the AppStream spec](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-description))