### PR TITLE
Configure Godot Flatpak so that OpenJDK 17 extension installs separately along with it

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -4,6 +4,7 @@
   <name>Godot</name>
   <summary>Godot game engine editor</summary>
   <developer_name>The Godot Engine Community</developer_name>
+  <launchable type="desktop-id">org.godotengine.Godot.desktop</launchable>
   <description>
     <p>
       <em>NOTE: This Flatpak is unofficial and not supported by Godot Engine developers.</em>

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -3,8 +3,6 @@ runtime: org.freedesktop.Sdk
 runtime-version: '23.08'
 default-branch: stable
 sdk: org.freedesktop.Sdk
-sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk17
 command: godot
 
 build-options:
@@ -47,14 +45,10 @@ finish-args:
   - --filesystem=host
   - --device=all
   - --talk-name=org.freedesktop.Flatpak
+  - --env=JAVA_HOME=/usr/lib/sdk/openjdk17
 
 modules:
   - shared-modules/glu/glu-9.json
-
-  - name: openjdk
-    buildsystem: simple
-    build-commands:
-      - /usr/lib/sdk/openjdk17/install.sh
 
   - name: scons
     buildsystem: simple
@@ -80,7 +74,7 @@ modules:
         dest-filename: godot.sh
         commands:
           - export APPDATA="$XDG_DATA_HOME"
-          - export PATH="/app/jre/bin:$PATH"
+          - if [ -f "$JAVA_HOME/enable.sh" ]; then source "$JAVA_HOME/enable.sh"; fi
           - /app/bin/godot-bin "$@"
 
       - type: file

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -5,7 +5,8 @@ default-branch: stable
 sdk: org.freedesktop.Sdk
 add-extensions:
   org.freedesktop.Sdk.Extension.openjdk17:
-    directory: openjdk17
+    directory: jdk
+    add-ld-path: jvm/openjdk-17
     subdirectories: true
     no-autodownload: false
 command: godot
@@ -50,7 +51,7 @@ finish-args:
   - --filesystem=host
   - --device=all
   - --talk-name=org.freedesktop.Flatpak
-  - --env=JAVA_HOME=/usr/lib/sdk/openjdk17
+  - --env=JAVA_HOME=/app/jdk
 
 modules:
   - shared-modules/glu/glu-9.json

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -3,6 +3,11 @@ runtime: org.freedesktop.Sdk
 runtime-version: '23.08'
 default-branch: stable
 sdk: org.freedesktop.Sdk
+add-extensions:
+  org.freedesktop.Sdk.Extension.openjdk17:
+    directory: openjdk17
+    subdirectories: true
+    no-autodownload: false
 command: godot
 
 build-options:


### PR DESCRIPTION
The reason why #155 stemmed from the need to revert changes made in #151 and #152 is because, while Java is available during build time, it _isn't_ always available afterwards to the end user, who might not have `org.freedesktop.Sdk.Extension.openjdk17` installed separately. This PR addresses that by making sure the OpenJDK 17 Flatpak gets installed _with_ the Godot Flatpak, and that the Godot Flatpak can access it. 

_May_ fix #157 as the OpenJDK 17 Flatpak includes Gradle binaries.