### PR TITLE
Try to fix SDK extension installation with Godot Flatpak

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -10,6 +10,8 @@ add-extensions:
     add-ld-path: jvm/openjdk-17
     no-autodownload: false
     autodelete: false
+cleanup-commands:
+  - mkdir -p /app/jdk
 command: godot
 
 build-options:

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -10,8 +10,6 @@ add-extensions:
     add-ld-path: jvm/openjdk-17
     no-autodownload: false
     autodelete: false
-cleanup-commands:
-  - mkdir -p /app/jdk
 command: godot
 
 build-options:

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -5,8 +5,8 @@ default-branch: stable
 sdk: org.freedesktop.Sdk
 add-extensions:
   org.freedesktop.Sdk.Extension.openjdk17:
-    version: '23.08'
     directory: jdk
+    version: '23.08'
     add-ld-path: jvm/openjdk-17
     subdirectories: true
     no-autodownload: false

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -5,6 +5,7 @@ default-branch: stable
 sdk: org.freedesktop.Sdk
 add-extensions:
   org.freedesktop.Sdk.Extension.openjdk17:
+    version: '23.08'
     directory: jdk
     add-ld-path: jvm/openjdk-17
     subdirectories: true

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -87,7 +87,7 @@ modules:
         dest-filename: godot.sh
         commands:
           - export APPDATA="$XDG_DATA_HOME"
-          - export PATH="/app/jdk/bin:$PATH"
+          - if [ -f "$JAVA_HOME/enable.sh" ]; then source "$JAVA_HOME/enable.sh"; fi
           - /app/bin/godot-bin "$@"
 
       - type: file

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -57,6 +57,12 @@ finish-args:
 modules:
   - shared-modules/glu/glu-9.json
 
+  - name: jdk
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/jdk
+      - ln -s jdk/jvm/openjdk-17 /app/jre
+
   - name: scons
     buildsystem: simple
     cleanup: ['*']

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -8,7 +8,6 @@ add-extensions:
     directory: jdk
     version: '23.08'
     add-ld-path: jvm/openjdk-17
-    subdirectories: true
     no-autodownload: false
 command: godot
 

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -56,11 +56,6 @@ finish-args:
 
 modules:
   - shared-modules/glu/glu-9.json
-  
-  - name: openjdk17
-    buildsystem: simple
-    build-commands:
-      - /usr/lib/sdk/openjdk17/installjdk.sh
 
   - name: jdk
     buildsystem: simple

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -9,6 +9,7 @@ add-extensions:
     version: '23.08'
     add-ld-path: jvm/openjdk-17
     no-autodownload: false
+    autodelete: false
 command: godot
 
 build-options:


### PR DESCRIPTION
When I tried to install the test build for #158, it seemed that the OpenJDK 17 SDK extension didn't install with it. In fact, I can't find a JDK in there at all.

Upon finding out #158 had just been merged before I got to fixing it, I thought I'd try to fix it with _this_ PR, otherwise Android builds will be basically non-existent. Please do not merge this PR until we're _absolutely_ sure Android exports can be built with it. I'm going to test it myself each time the test build succeeds, and I highly encourage others who want to test each coming test build to do the same.