### PR TITLE
JDK extension setup cleanup after #160

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -7,7 +7,6 @@ add-extensions:
   org.freedesktop.Sdk.Extension.openjdk17:
     directory: jdk
     version: '23.08'
-    add-ld-path: jvm/openjdk-17
     no-autodownload: false
     autodelete: false
 command: godot
@@ -52,7 +51,6 @@ finish-args:
   - --filesystem=host
   - --device=all
   - --talk-name=org.freedesktop.Flatpak
-  - --env=JAVA_HOME=/app/jdk
 
 modules:
   - shared-modules/glu/glu-9.json
@@ -61,7 +59,6 @@ modules:
     buildsystem: simple
     build-commands:
       - mkdir -p /app/jdk
-      - ln -s jdk/jvm/openjdk-17 /app/jre
 
   - name: scons
     buildsystem: simple
@@ -87,7 +84,7 @@ modules:
         dest-filename: godot.sh
         commands:
           - export APPDATA="$XDG_DATA_HOME"
-          - if [ -f "$JAVA_HOME/enable.sh" ]; then source "$JAVA_HOME/enable.sh"; fi
+          - if [ -f /app/jdk/enable.sh ]; then source /app/jdk/enable.sh; fi
           - /app/bin/godot-bin "$@"
 
       - type: file


### PR DESCRIPTION
After #160, installing `org.godotengine.Godot` from Flathub will have `org.freedesktop.Sdk.Extension.openjdk17` installed together so that flatpak godot do not need to bundle JDK itself. This PR does the clean up of unused steps since #151 from manifest including:

- unused `add-ld-path` (no need to add lib path to `LD_LIBRARY_PATH` as jdk executables have rpath to `../lib`)
- unused symlink `/app/jre` (it is not used by wrapper script anymore)
- unused override-able `JAVA_HOME` variable as we have already configured JDK path to located at `/app/jdk`