### PR TITLE
Add Flatpak External Data Checker configuration for Godot and SCons

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,30 @@
+name: Check for updates
+on:
+  schedule: # for scheduling to work this file must be in the default branch
+  - cron: "0 * * * *" # run every hour
+  workflow_dispatch: # can be manually dispatched under GitHub's "Actions" tab 
+
+jobs:
+  flatpak-external-data-checker:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        branch: [ master ] # list all branches to check
+    
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+
+      - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
+        env:
+          GIT_AUTHOR_NAME: Flatpak External Data Checker
+          GIT_COMMITTER_NAME: Flatpak External Data Checker
+          # email sets "github-actions[bot]" as commit author, see https://github.community/t/github-actions-bot-email-address/17204/6
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --update --never-fork org.godotengine.Godot.yaml

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -69,8 +69,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: 3d43b2303a924816ea0e1b345ff04c9b3e27b53eadf0f26012fc0c29b019685f
-        url: https://downloads.sourceforge.net/project/scons/scons/4.4.0/SCons-4.4.0.tar.gz
+        sha256: d9fcd831700ce373ecd30ac55e9d7eff20754215cff5967c4972237d614a326e
+        url: https://downloads.sourceforge.net/project/scons/scons/4.7.0/SCons-4.7.0.tar.gz
         x-checker-data:
           type: anitya
           project-id: 4770

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -71,6 +71,10 @@ modules:
       - type: archive
         sha256: 3d43b2303a924816ea0e1b345ff04c9b3e27b53eadf0f26012fc0c29b019685f
         url: https://downloads.sourceforge.net/project/scons/scons/4.4.0/SCons-4.4.0.tar.gz
+        x-checker-data:
+          type: anitya
+          project-id: 4770
+          url-template: https://downloads.sourceforge.net/project/scons/scons/$version/SCons-$version.tar.gz
 
     build-commands:
       - pip3 install --no-index --no-build-isolation --prefix=/app .

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -81,7 +81,11 @@ modules:
     sources:
       - type: archive
         sha256: da14e36448f1efd2955fe85d7ededc9e6ac8c893f76723b4852e7587306c761d
-        url: https://downloads.tuxfamily.org/godotengine/4.2.2/godot-4.2.2-stable.tar.xz
+        url: https://github.com/godotengine/godot/releases/download/4.2.2-stable/godot-4.2.2-stable.tar.xz
+        x-checker-data:
+          type: anitya
+          project-id: 12162
+          url-template: https://github.com/godotengine/godot/releases/download/$version/godot-$version.tar.xz
 
       - type: script
         dest-filename: godot.sh


### PR DESCRIPTION
Fixes #163.

I have also added a GitHub Actions configuration file on this PR, but it may not get automatically set up once this PR get merged. If GitHub Actions doesn't get set up once this PR gets merged, it could be that we have to get it set up manually or remove the preset configuration entirely (note that several repositories [such as this one](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk21) have the external data checker running on them _without_ a GitHub Actions workflow).  