### PR TITLE
Update Godot to 4.3-beta2 for Flathub Beta

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -48,6 +48,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="4.3-beta2" date="2024-06-20"/>
     <release version="4.3-beta1" date="2024-05-31"/>
     <release version="4.2.2" date="2024-04-17"/>
     <release version="4.2.1" date="2023-12-12"/>

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -68,8 +68,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: 26006799117179a82951525306b6eacc90a8d1c7862aa2190b553e3b4f095948
-        url: https://github.com/godotengine/godot-builds/releases/download/4.3-beta1/godot-4.3-beta1.tar.xz
+        sha256: 721d315850ee0e7d8122278a8a0b26e500c4f7d3b0dbf6bfefe103a6587a76a9
+        url: https://downloads.tuxfamily.org/godotengine/4.3/beta2/godot-4.3-beta2.tar.xz
 
       - type: script
         dest-filename: godot.sh


### PR DESCRIPTION
Return to using TuxFamily download links for Godot sources as TuxFamily is now back up.