### PR TITLE
Update Godot to 4.3 RC 2 for Flathub Beta

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -48,6 +48,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="4.3-rc2" date="2024-08-01"/>
     <release version="4.3-rc1" date="2024-07-25"/>
     <release version="4.2.2" date="2024-04-17"/>
     <release version="4.2.1" date="2023-12-12"/>

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -68,8 +68,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: e71b9589359d1b1c4aa7b7925eb1893644c636882c9a95524ffdd07c69a70353
-        url: https://downloads.tuxfamily.org/godotengine/4.3/rc1/godot-4.3-rc1.tar.xz
+        sha256: 8947f4d9b0cc1e924470f46cd0cc7a057738680c305a750c53aa214254b6ade2
+        url: https://github.com/godotengine/godot-builds/releases/download/4.3-rc2/godot-4.3-rc2.tar.xz
 
       - type: script
         dest-filename: godot.sh


### PR DESCRIPTION
I used the GitHub download link for this one because the files haven't been uploaded to TuxFamily yet (as of me opening this PR).