### PR TITLE
Use new Anitya project ID for Godot sources

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -137,7 +137,7 @@ modules:
         url: https://github.com/godotengine/godot/releases/download/4.3-stable/godot-4.3-stable.tar.xz
         x-checker-data:
           type: anitya
-          project-id: 12162
+          project-id: 373975
           url-template: https://github.com/godotengine/godot/releases/download/$version/godot-$version.tar.xz
 
       - type: script


### PR DESCRIPTION
Partially addresses #183

It doesn't fix the `No such file or directory: '/github/workspace/shared-modules/glu/glu-9.json'` warning (though _that_ module has no `x-checker-data` set yet), but this should _at least_ fix the checking error for Godot's source code. [The old project ID doesn't work anymore for some reason, as its Anitya page now shows a 404 error.](https://release-monitoring.org/project/12162/)