### PR TITLE
Fix typos in Flatpak External Data Checker URL template

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -138,7 +138,7 @@ modules:
         x-checker-data:
           type: anitya
           project-id: 373975
-          url-template: https://github.com/godotengine/godot/releases/download/$version/godot-$version.tar.xz
+          url-template: https://github.com/godotengine/godot/releases/download/$version-stable/godot-$version-stable.tar.xz
 
       - type: script
         dest-filename: godot.sh


### PR DESCRIPTION
Addresses Flatpak External Data checker errors in #183, specifically [here](https://github.com/flathub/org.godotengine.Godot/issues/183#issuecomment-2308984808), originally written by @Calinou (sorry for the ping):

> I still get this notification every hour as of [9c77d1f](https://github.com/flathub/org.godotengine.Godot/commit/9c77d1f609f994b98e12f92ae8327fff16aba1ca):
> 
> ```
> Run docker://ghcr.io/flathub/flatpak-external-data-checker:latest
> /usr/bin/docker run --name ghcrioflathubflatpakexternaldatacheckerlatest_ee5493 --label 12b425 --workdir /github/workspace --rm -e "GIT_AUTHOR_NAME" -e "GIT_COMMITTER_NAME" -e "GIT_AUTHOR_EMAIL" -e "GIT_COMMITTER_EMAIL" -e "EMAIL" -e "GITHUB_TOKEN" -e "INPUT_ARGS" -e "HOME" -e "GITHUB_JOB" -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_REPOSITORY_OWNER_ID" -e "GITHUB_RUN_ID" -e "GITHUB_RUN_NUMBER" -e "GITHUB_RETENTION_DAYS" -e "GITHUB_RUN_ATTEMPT" -e "GITHUB_REPOSITORY_ID" -e "GITHUB_ACTOR_ID" -e "GITHUB_ACTOR" -e "GITHUB_TRIGGERING_ACTOR" -e "GITHUB_WORKFLOW" -e "GITHUB_HEAD_REF" -e "GITHUB_BASE_REF" -e "GITHUB_EVENT_NAME" -e "GITHUB_SERVER_URL" -e "GITHUB_API_URL" -e "GITHUB_GRAPHQL_URL" -e "GITHUB_REF_NAME" -e "GITHUB_REF_PROTECTED" -e "GITHUB_REF_TYPE" -e "GITHUB_WORKFLOW_REF" -e "GITHUB_WORKFLOW_SHA" -e "GITHUB_WORKSPACE" -e "GITHUB_ACTION" -e "GITHUB_EVENT_PATH" -e "GITHUB_ACTION_REPOSITORY" -e "GITHUB_ACTION_REF" -e "GITHUB_PATH" -e "GITHUB_ENV" -e "GITHUB_STEP_SUMMARY" -e "GITHUB_STATE" -e "GITHUB_OUTPUT" -e "RUNNER_OS" -e "RUNNER_ARCH" -e "RUNNER_NAME" -e "RUNNER_ENVIRONMENT" -e "RUNNER_TOOL_CACHE" -e "RUNNER_TEMP" -e "RUNNER_WORKSPACE" -e "ACTIONS_RUNTIME_URL" -e "ACTIONS_RUNTIME_TOKEN" -e "ACTIONS_CACHE_URL" -e "ACTIONS_RESULTS_URL" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/org.godotengine.Godot/org.godotengine.Godot":"/github/workspace" ghcr.io/flathub/flatpak-external-data-checker:latest --update --never-fork org.godotengine.Godot.yaml
> INFO    src.manifest: Loading module from shared-modules/glu/glu-9.json
> WARNING src.manifest: Can't open manifest file: [Errno 2] No such file or directory: '/github/workspace/shared-modules/glu/glu-9.json'
> INFO    src.manifest: Checking 4 external data items
> INFO    src.manifest: Started check [1/4] archive dotconf/v1.4.1.tar.gz (from org.godotengine.Godot.yaml)
> INFO    src.manifest: Started check [2/4] archive libspeechd/speech-dispatcher-0.11.5.tar.gz (from org.godotengine.Godot.yaml)
> INFO    src.manifest: Started check [3/4] archive scons/SCons-4.8.0.tar.gz (from org.godotengine.Godot.yaml)
> INFO    src.manifest: Started check [4/4] archive godot-tools/godot-4.3-stable.tar.xz (from org.godotengine.Godot.yaml)
> INFO    src.manifest: Finished check [1/4] archive dotconf/v1.4.1.tar.gz (from org.godotengine.Godot.yaml)
> INFO    src.manifest: Finished check [2/4] archive scons/SCons-4.8.0.tar.gz (from org.godotengine.Godot.yaml)
> INFO    src.manifest: Finished check [3/4] archive libspeechd/speech-dispatcher-0.11.5.tar.gz (from org.godotengine.Godot.yaml)
> ERROR   src.manifest: Failed to check archive godot-tools/godot-4.3-stable.tar.xz with AnityaChecker: Error downloading upstream source: 404, message='Not Found', url=URL('https://github.com/godotengine/godot/releases/download/4.3/godot-4.3.tar.xz')
> WARNING src.main: Check finished with 1 error(s)
> ```

 