### PR TITLE
Update Godot to 4.4-dev4 for Flathub Beta

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -48,6 +48,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="4.4-dev4" date="2024-11-08"/>
     <release version="4.4-dev3" date="2024-10-02"/>
     <release version="4.4-dev2" date="2024-09-10"/>
     <release version="4.4-dev1" date="2024-08-26"/>

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -67,8 +67,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: e4ce0f6d64d29fc843c4ab35ebcf680cd9eede94373e07be80d35ce98ba9248b
-        url: https://downloads.tuxfamily.org/godotengine/4.4/dev3/godot-4.4-dev3.tar.xz
+        sha256: e32020510f2b7a63284e09db332f8f95398bfdf9b77242d05e5de00e8d5032e6
+        url: https://github.com/godotengine/godot-builds/releases/download/4.4-dev4/godot-4.4-dev4.tar.xz
 
       - type: script
         dest-filename: godot.sh


### PR DESCRIPTION
Using GitHub downloads link this time as files for 4.4-dev4 haven't been uploaded to TuxFamily yet (at the time this PR has been opened).