### PR TITLE
Update Godot to 4.4-dev5 for Flathub Beta

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -48,6 +48,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="4.4-dev5" date="2024-11-21"/>
     <release version="4.4-dev4" date="2024-11-08"/>
     <release version="4.4-dev3" date="2024-10-02"/>
     <release version="4.4-dev2" date="2024-09-10"/>

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -1,7 +1,13 @@
 app-id: org.godotengine.Godot
 runtime: org.freedesktop.Sdk
-runtime-version: '23.08'
+runtime-version: &runtime-version '24.08'
 sdk: org.freedesktop.Sdk
+add-extensions:
+  org.freedesktop.Sdk.Extension.openjdk17:
+    directory: jdk
+    version: *runtime-version
+    no-autodownload: false
+    autodelete: false
 command: godot
 
 build-options:

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -73,8 +73,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: e32020510f2b7a63284e09db332f8f95398bfdf9b77242d05e5de00e8d5032e6
-        url: https://github.com/godotengine/godot-builds/releases/download/4.4-dev4/godot-4.4-dev4.tar.xz
+        sha256: 2fc6d31d4d5768a0a6e2179b5d909b9d8fb558db9db2123bfcd6bed094a45b35
+        url: https://github.com/godotengine/godot-builds/releases/download/4.4-dev5/godot-4.4-dev5.tar.xz
 
       - type: script
         dest-filename: godot.sh


### PR DESCRIPTION
Also incorporate @MateusRodCosta's Freedesktop runtime upgrade from #191 (sorry for the ping).