### PR TITLE
Use system-provided ICU libraries

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -39,6 +39,7 @@ build-options:
       builtin_zlib=no
       builtin_graphite=no
       builtin_harfbuzz=no
+      builtin_icu4c=no
       udev=no
 finish-args:
   - --share=ipc


### PR DESCRIPTION
Building Godot with `freetype, libpng, zlib, graphite, harfbuzz` as system-provided while leaving `icu4c` as built-in leads to editor crash when loading GDExtension libraries that uses `std::call_once` in static initialization.

Please refer to godotengine/godot#91401 for details.

While godotengine/godot#99883 is not merged yet at the time of writing, unofficial Godot builds could change build configuration to use system-provided `icu4c` libraries, so that it can open minimal reproduction project like https://github.com/j20001970/godot_static_call_once_crash successfully like official build.