### PR TITLE
Update to 4.4-dev6

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,30 @@
+name: Check for updates
+on:
+  schedule: # for scheduling to work this file must be in the default branch
+  - cron: "0 * * * *" # run every hour
+  workflow_dispatch: # can be manually dispatched under GitHub's "Actions" tab 
+
+jobs:
+  flatpak-external-data-checker:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        branch: [ master ] # list all branches to check
+    
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+
+      - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
+        env:
+          GIT_AUTHOR_NAME: Flatpak External Data Checker
+          GIT_COMMITTER_NAME: Flatpak External Data Checker
+          # email sets "github-actions[bot]" as commit author, see https://github.community/t/github-actions-bot-email-address/17204/6
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --update --never-fork org.godotengine.Godot.yaml

--- a/README.md
+++ b/README.md
@@ -72,8 +72,7 @@ Exec Flags: --host code --reuse-window {project} --goto {file}:{line}:{col}
 
 ## Limitations
 
-- No C#/Mono support
-  ([#8](https://github.com/flathub/org.godotengine.Godot/issues/8)).
+- For C#/Mono support, install [org.godotengine.GodotSharp](https://flathub.org/apps/org.godotengine.GodotSharp) instead.
 
 ## Building from source
 
@@ -84,7 +83,7 @@ then enter the following commands in a terminal:
 ```bash
 git clone --recursive https://github.com/flathub/org.godotengine.Godot.git
 cd org.godotengine.Godot/
-flatpak install --user flathub org.freedesktop.Sdk//22.08 -y
+flatpak install --user flathub org.freedesktop.Sdk//24.08 -y
 flatpak-builder --force-clean --install --user -y builddir org.godotengine.Godot.yaml
 ```
 

--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -56,6 +56,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="4.4-dev6" date="2024-12-05"/>
     <release version="4.4-dev5" date="2024-11-21"/>
     <release version="4.4-dev4" date="2024-11-08"/>
     <release version="4.4-dev3" date="2024-10-02"/>

--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <id>org.godotengine.Godot.desktop</id>
-  <name>Godot</name>
-  <summary>Godot game engine editor</summary>
+  <name>Godot Engine</name>
+  <summary>Easily create 2D and 3D games</summary>
   <developer_name>The Godot Engine Community</developer_name>
   <launchable type="desktop-id">org.godotengine.Godot.desktop</launchable>
   <description>
-    <p>Godot is an advanced, feature-packed, multi-platform 2D and 3D open source game engine.</p>
-    <p>Create games with ease, using Godot's unique approach to game development.</p>
+    <p>
+      <em>NOTE: This Flatpak is unofficial and not supported by Godot Engine developers.</em>
+      Find officially supported binaries on godotengine.org.
+    </p>
+    <p>The feature-packed, cross-platform game engine to create 2D and 3D games from a unified interface. Godot Engine provides a comprehensive set of common tools, so that you can focus on making games without having to reinvent the wheel. Games can be exported in one click to a number of platforms, including the major desktop platforms (Linux, macOS, Windows) as well as mobile (Android, iOS), web-based (HTML5) platforms and consoles (Switch, PS4 and Xbox One - via thirdparty publishers).</p>
+    <p>Completely free and open source under the very permissive MIT license. No strings attached, no royalties, nothing. Your game is yours down to the last line of engine code. Godot's development is fully independent and community-driven, empowering you to help shape the engine to match your expectations. It is supported by the non-profit Godot Foundation.</p>
+    <p>Create games with ease, using Godot's unique approach to game development:</p>
     <ul>
       <li>Nodes for all your needs. Godot comes with hundreds of built-in nodes that make game design a breeze. You can also create your own for custom behaviors, editors and much more.</li>
       <li>Flexible scene system. Create node compositions with support for instancing and inheritance.</li>
@@ -16,12 +21,12 @@
       <li>Persistent live editing where changes are not lost after stopping the game. It even works on mobile devices!</li>
       <li>Create your own custom tools with ease using the incredible tool system.</li>
     </ul>
-    <p>Limitations of the Flatpak version:</p>
+    <p>Current limitations of this Flatpak version:</p>
     <ul>
-      <li>No C#/Mono support. See: https://github.com/flathub/org.godotengine.Godot/issues/8</li>
-      <li>Custom builds for Android don't work. See: https://github.com/flathub/org.godotengine.Godot/issues/63</li>
-      <li>The old-fashioned way of exporting to Android still works: https://docs.godotengine.org/en/latest/tutorials/export/exporting_for_android.html</li>
+      <li>For C#/Mono support, install org.godotengine.GodotSharp instead: https://flathub.org/apps/org.godotengine.GodotSharp</li>
       <li>External script editors are supported, but you need to follow the steps described here: https://github.com/flathub/org.godotengine.Godot#using-an-external-script-editor</li>
+      <li>Godot 4's Blender importer is supported, but Blender needs to be installed on your system and you need to follow the steps described here: https://github.com/flathub/org.godotengine.Godot#using-blender</li>
+      <li>For projects using text-to-speech, make sure speech-dispatcher is installed on your system, so that this Flatpak can access it.</li>
     </ul>
   </description>
   <metadata_license>CC0-1.0</metadata_license>
@@ -32,17 +37,20 @@
   <url type="help">https://docs.godotengine.org</url>
   <url type="donation">https://godotengine.org/donate</url>
   <url type="translate">https://hosted.weblate.org/projects/godot-engine/godot</url>
+  <url type="contact">https://godotengine.org/contact/</url>
+  <url type="vcs-browser">https://github.com/godotengine/godot</url>
+  <url type="contribute">https://docs.godotengine.org/en/stable/contributing/how_to_contribute.html</url>
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://godotengine.org/storage/app/media/3.0%20release/gltf.png</image>
+      <image type="source">https://raw.githubusercontent.com/godotengine/godot-website/9a476ed665642572ecc4c54c0b3753f7e2b60b7f/storage/app/media/3.0%20release/gltf.png</image>
       <caption>Texture Viewer</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://godotengine.org/storage/app/media/3.0%20release/visual_script.png</image>
-      <caption>Visual Scripting</caption>
+      <image type="source">https://raw.githubusercontent.com/godotengine/godot-website/9a476ed665642572ecc4c54c0b3753f7e2b60b7f/storage/blog/godot-4-0-sets-sail/08-editor-new-ui-editing-options.png</image>
+      <caption>Godot Editor (2D/UI view)</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://godotengine.org/storage/app/media/3.0%20release/particles.png</image>
+      <image type="source">https://raw.githubusercontent.com/godotengine/godot-website/9a476ed665642572ecc4c54c0b3753f7e2b60b7f/storage/app/media/3.0%20release/particles.png</image>
       <caption>Particle Viewer</caption>
     </screenshot>
   </screenshots>

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -131,8 +131,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: 2fc6d31d4d5768a0a6e2179b5d909b9d8fb558db9db2123bfcd6bed094a45b35
-        url: https://github.com/godotengine/godot-builds/releases/download/4.4-dev5/godot-4.4-dev5.tar.xz
+        sha256: 57b167ae8e6808ab9d589da26069e66abaad83e33b83de7004355c415493b902
+        url: https://github.com/godotengine/godot-builds/releases/download/4.4-dev6/godot-4.4-dev6.tar.xz
 
       - type: script
         dest-filename: godot.sh

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -27,8 +27,6 @@ build-options:
     SCONS_FLAGS: >
       platform=linuxbsd
       CCFLAGS=-I/app/include
-      prefix=/app
-      unix_global_settings_path=/app
       progress=no
       builtin_freetype=no
       builtin_libogg=no
@@ -49,12 +47,68 @@ finish-args:
   - --share=network
   - --socket=pulseaudio
   - --filesystem=host
+  - --filesystem=xdg-run/speech-dispatcher # For TTS via libspeechd
   - --device=all
   - --talk-name=org.freedesktop.Flatpak
-  - --env=JAVA_HOME=/usr/lib/sdk/openjdk17
 
 modules:
   - shared-modules/glu/glu-9.json
+
+  - name: jdk
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/jdk
+
+  # This section is borrowed from:
+  # https://github.com/flathub/org.electronjs.Electron2.BaseApp/blob/c4635368f6c11ace8c1290525da4435d13d9173f/org.electronjs.Electron2.BaseApp.yml#L103
+  # https://github.com/flathub/net.lutris.Lutris/blob/76e94a0b80ef3ebc1b9a6b61f47d736f5ddd772c/net.lutris.Lutris.yml#L495
+  # https://gitlab.archlinux.org/archlinux/packaging/packages/speech-dispatcher/-/blob/414baaf78b5fe416df88a89ac18d2dd579a0c653/PKGBUILD
+  - name: libspeechd
+    config-opts:
+      - --disable-static
+      - --with-ibmtts=no
+      - --with-kali=no
+      - --with-baratinoo=no
+      - --with-voxin=no
+      - --without-flite
+      - --disable-python
+    no-make-install: true
+    post-install:
+      - cd ./src/api/c && make install
+    cleanup:
+      - '*.la'
+      - '*.a'
+      - /include
+
+    sources:
+      - type: archive
+        url: https://github.com/brailcom/speechd/releases/download/0.11.5/speech-dispatcher-0.11.5.tar.gz
+        sha512: d6d880bce0ae5bc2a5d519ef7740c689ae8b4b0bb658379762810e4beae3e465a429fbe19f7c490e89db0ea6a36aedd4b2287ac9251b90059b5c2cb3c0dd8a28
+        x-checker-data:
+          type: anitya
+          project-id: 13411
+          stable-only: true
+          url-template: https://github.com/brailcom/speechd/releases/download/$version/speech-dispatcher-$version.tar.gz
+
+    modules:
+      # dotconf provides utility functions to parse config files. It's only linked with the speech-dispatcher server,
+      # which we aren't building, but it needs to exist to get past the ./configure step anyway
+      - name: dotconf
+        sources:
+          - type: archive
+            url: https://github.com/williamh/dotconf/archive/refs/tags/v1.4.1.tar.gz
+            sha512: a6cada8621295b268d4b4fd85bc0c207e78324c9e84754ead2fdf6c1598ec8bdf626f9c24e66063d921c95d73e83b50ab50416a9b4c9a7a631392552ec46f55a
+            x-checker-data:
+              type: anitya
+              project-id: 13410
+              url-template: https://github.com/williamh/dotconf/archive/refs/tags/v$version.tar.gz
+
+          - type: script
+            commands:
+              - autoreconf -fiv
+            dest-filename: autogen.sh
+        cleanup:
+          - '*'
 
   - name: scons
     buildsystem: simple
@@ -62,8 +116,12 @@ modules:
 
     sources:
       - type: archive
-        sha256: 3d43b2303a924816ea0e1b345ff04c9b3e27b53eadf0f26012fc0c29b019685f
-        url: https://downloads.sourceforge.net/project/scons/scons/4.4.0/SCons-4.4.0.tar.gz
+        sha256: cad573b329b6a5bc7e654b01f0231064acc979026af68a9e467ddb32bf2ee501
+        url: https://downloads.sourceforge.net/project/scons/scons/4.8.1/SCons-4.8.1.tar.gz
+        x-checker-data:
+          type: anitya
+          project-id: 4770
+          url-template: https://downloads.sourceforge.net/project/scons/scons/$version/SCons-$version.tar.gz
 
     build-commands:
       - pip3 install --no-index --no-build-isolation --prefix=/app .
@@ -80,7 +138,7 @@ modules:
         dest-filename: godot.sh
         commands:
           - export APPDATA="$XDG_DATA_HOME"
-          - if [ -f "$JAVA_HOME/enable.sh" ]; then source "$JAVA_HOME/enable.sh"; fi
+          - if [ -f /app/jdk/enable.sh ]; then source /app/jdk/enable.sh; fi
           - /app/bin/godot-bin "$@"
 
       - type: file


### PR DESCRIPTION
Although this looks big, it's just a merge of `master` (which fixes  #196), plus #197, and then an update to the latest dev release, so only the last 3 patches are new.


```
$ git log --graph --decorate --pretty=oneline --abbrev-commit master~.. beta~..
* 86f6c0e (HEAD -> update-to-4.4-dev6, origin/update-to-4.4-dev6) Update to Godot 4.4-dev6
*   f80ae5c Merge with stable branch
|\  
| * 87595c9 (origin/update-README, update-README) README: update local build instructions
| * 4d6f763 (upstream/master, upstream/HEAD, master) Update to fdo 24.08 (#191)
* e2ead0d (upstream/beta, beta) Update Godot to 4.4-dev5 for Flathub Beta (#194)
```

Diff to master:

```
diff --git a/README.md b/README.md
index 4fc7c94..4fb5b14 100644
--- a/README.md
+++ b/README.md
@@ -84,5 +84,5 @@ then enter the following commands in a terminal:
 git clone --recursive https://github.com/flathub/org.godotengine.Godot.git
 cd org.godotengine.Godot/
-flatpak install --user flathub org.freedesktop.Sdk//23.08 -y
+flatpak install --user flathub org.freedesktop.Sdk//24.08 -y
 flatpak-builder --force-clean --install --user -y builddir org.godotengine.Godot.yaml
 
diff --git a/org.godotengine.Godot.appdata.xml b/org.godotengine.Godot.appdata.xml
index 84400cc..2346123 100644
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -56,6 +56,12 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="4.4-dev6" date="2024-12-05"/>
+    <release version="4.4-dev5" date="2024-11-21"/>
+    <release version="4.4-dev4" date="2024-11-08"/>
+    <release version="4.4-dev3" date="2024-10-02"/>
+    <release version="4.4-dev2" date="2024-09-10"/>
+    <release version="4.4-dev1" date="2024-08-26"/>
     <release version="4.3" date="2024-08-15"/>
     <release version="4.2.2" date="2024-04-17"/>
     <release version="4.2.1" date="2023-12-12"/>
diff --git a/org.godotengine.Godot.yaml b/org.godotengine.Godot.yaml
index 9823e1d..b685419 100644
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -131,12 +131,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: 751e55bfad8e04b846f9cf7b6eb80e058986a2cb1b103fc0fe6a4d8526a20e56
-        url: https://github.com/godotengine/godot/releases/download/4.3-stable/godot-4.3-stable.tar.xz
-        x-checker-data:
-          type: anitya
-          project-id: 373975
-          url-template: https://github.com/godotengine/godot/releases/download/$version-stable/godot-$version-stable.tar.xz
+        sha256: 57b167ae8e6808ab9d589da26069e66abaad83e33b83de7004355c415493b902
+        url: https://github.com/godotengine/godot-builds/releases/download/4.4-dev6/godot-4.4-dev6.tar.xz
 
       - type: script
         dest-filename: godot.sh
```