### PR TITLE
MetaInfo: Add brand colors

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -55,6 +55,10 @@
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1"/>
+  <branding>
+    <color type="primary" scheme_preference="light">#a5d7ff</color>
+    <color type="primary" scheme_preference="dark">#2d3c67</color>
+  </branding>
   <releases>
     <release version="4.4.1" date="2025-03-26">
       <description></description>


### PR DESCRIPTION
This adds some complementary [brand colors](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines#good-brand-colors) e.g. for Flathub and GNOME Software. Preview, as provided by the [Flathub banner previewer](https://docs.flathub.org/banner-preview/):

![Screenshot 2025-02-23 at 14-20-31 Brand color preview Flathub Documentation](https://github.com/user-attachments/assets/ce8b8ecc-72f0-4eb6-809a-52196e0419b6)
