### PR TITLE
Use builtin harfbuzz to workaround GDExtension crash

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -38,7 +38,6 @@ build-options:
       builtin_libvpx=no
       builtin_zlib=no
       builtin_graphite=no
-      builtin_harfbuzz=no
       udev=no
 finish-args:
   - --share=ipc


### PR DESCRIPTION
Since godotengine/godot#100052 is merged in v4.4, we can now configure linux dependency modules independently.

Currently Godot has a bug (godotengine/godot#91401) that if the engine is using system-provided harfbuzz library, it will crash when GDExtension libraries call `std::call_once` during static initialization. Libraries with such pattern are including but not limited to Tensorflow/Protobuf-based projects, GDExtension libraries with these dependencies will always crash flatpak Godot unless builtin harfbuzz is used.

This PR remove the `builtin_harfbuzz=no` from Scons flags, making the editor to use builtin harfbuzz instead of system-provided one from Freedesktop SDK/Platform. The editor executable size increase in my testing is from `139.2 MiB (145,966,624)` to `139.9 MiB (146,660,800)` which is acceptable at the scale of flatpak apps IMO.