### PR TITLE
appdata: Tweak unofficial note once more for better display on Flathub website

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -6,10 +6,7 @@
   <developer_name>The Godot Engine Community</developer_name>
   <launchable type="desktop-id">org.godotengine.Godot.desktop</launchable>
   <description>
-    <p>
-      **This is a community package of Godot Engine and not officially supported by the Godot Foundation.**
-      Find officially supported binaries on godotengine.org.
-    </p>
+    <p>**This is a community package of Godot Engine and not officially supported by the Godot Foundation. Find officially supported binaries on godotengine.org.**</p>
     <p>The feature-packed, cross-platform game engine to create 2D and 3D games from a unified interface. Godot Engine provides a comprehensive set of common tools, so that you can focus on making games without having to reinvent the wheel. Games can be exported in one click to a number of platforms, including the major desktop platforms (Linux, macOS, Windows) as well as mobile (Android, iOS), web-based (HTML5) platforms and consoles (Switch, PS4 and Xbox One - via thirdparty publishers).</p>
     <p>Completely free and open source under the very permissive MIT license. No strings attached, no royalties, nothing. Your game is yours down to the last line of engine code. Godot's development is fully independent and community-driven, empowering you to help shape the engine to match your expectations. It is supported by the non-profit Godot Foundation.</p>
     <p>Create games with ease, using Godot's unique approach to game development:</p>


### PR DESCRIPTION
In commit 2d024ac795801631ecd5e6bb2cd9e1cfc704741d an attempt was made to follow these instructions from the Flathub website <https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#website-specific-formatting>:

> The Flathub website will make the content of any `<p>` tag bold, if it
> is enclosed inside `**` like below. Some new submissions may need to
> use this in some cases, please see the requirements.
>
> ```
> <description>
>   <p>**Make this line bold please**</p>
> </description>
> ```

And this one <https://docs.flathub.org/docs/for-app-authors/requirements#description-notes>:

> Unofficially packaged, proprietary submissions must add a note like
> below as the first `<p>` tag of description.
>
> Unofficially packaged, open source submissions may also follow this.
>
> ```
> <description>
>   <p>**This is a community package of APP NAME and not officially supported by UPSTREAM NAME.**</p>
> </description>
> ```

However what was done in that commit was to wrap just one sentence within the `<p>` tags with `**`. I believe this is why https://flathub.org/en/apps/org.godotengine.Godot shows the stars verbatim.

Wrap the whole paragraph in stars, without any whitespace between the `<p>` / `</p>` and the stars.

(For the record, I think Flathub has chosen a chaotic path here, to give `**` special meaning when `<em>` was right there, `<strong>` could easily enough have been added to the AppStream spec, or even some kind of machine-parsable way to flag an app as unofficially packaged; but here we are.)

Resolves https://github.com/flathub/org.godotengine.Godot/issues/229