### PR TITLE
Update Godot from 4.5.1 to 4.6.0

### DIFF
--- a/org.godotengine.Godot.appdata.xml
+++ b/org.godotengine.Godot.appdata.xml
@@ -57,8 +57,11 @@
     <color type="primary" scheme_preference="dark">#2d3c67</color>
   </branding>
   <releases>
-    <release version="4.5.1" date="2025-10-15">
+    <release version="4.6" date="2026-01-26">
       <description></description>
+    </release>
+    <release version="4.5.1" date="2025-10-15">
+      <description/>
     </release>
     <release version="4.5" date="2025-09-15">
       <description/>

--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -132,8 +132,8 @@ modules:
     buildsystem: simple
     sources:
       - type: archive
-        url: https://github.com/godotengine/godot-accesskit-c-static/releases/download/0.17.0/accesskit-c-0.17.0.zip
-        sha256: 053ce758ae9a84c4870ebc64894ab8798773fcca221840f262001e0eaa305b18
+        url: https://github.com/godotengine/godot-accesskit-c-static/releases/download/0.18.0/accesskit-c-0.18.0.zip
+        sha256: 967c457e13c6adbe43f875b3c3bd9984e9e0e8e9708a1e82f396ea0364b5e593
     build-commands:
       - mkdir -p /app/accesskit-c
       - cp -r include lib /app/accesskit-c/
@@ -145,8 +145,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: 559e11bdd85033640d49db67baa6f15be1128b2af38a5acc06e02b53363d8dde
-        url: https://github.com/godotengine/godot/releases/download/4.5.1-stable/godot-4.5.1-stable.tar.xz
+        sha256: 900ad0f6241b8051daa569cee1b07b6e30c4cb4f804471f72256d052334c0550
+        url: https://github.com/godotengine/godot/releases/download/4.6-stable/godot-4.6-stable.tar.xz
         x-checker-data:
           type: anitya
           project-id: 373975


### PR DESCRIPTION
Updates Godot from 4.5.1 to 4.6.0. This includes upgrading godot-accesskit from 0.17.0 to 0.18.0. The inclusion of the accesskit bump was inspired by [these CI failure logs](https://github.com/flathub-infra/vorarbeiter/actions/runs/21401118522/job/61612253009) and [this line](https://github.com/godotengine/godot/blob/77579f93e6ee7cf2515da4a7a5000d8a0244be98/.github/workflows/linux_builds.yml#L11) in the Godot build files that shows Godot 4.6.0 requires accesskit 0.18.0.

References
- https://github.com/godotengine/godot/releases/tag/4.6-stable
- https://github.com/godotengine/godot-accesskit-c-static/releases/tag/0.18.0
- https://github.com/godotengine/godot/pull/113990

Supersedes https://github.com/flathub/org.godotengine.Godot/pull/228, https://github.com/flathub/org.godotengine.Godot/pull/232
Resolves https://github.com/flathub/org.godotengine.Godot/issues/233