### PR TITLE
Remove org.freedesktop.ScreenSaver sandbox hole

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -51,7 +51,6 @@ finish-args:
   - --filesystem=xdg-run/speech-dispatcher # For TTS via libspeechd
   - --device=all
   - --talk-name=org.freedesktop.Flatpak
-  - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.a11y.Bus # For screen reader accessibility via AT-SPI
 
 modules:


### PR DESCRIPTION
Godot 4.6 supports using the Inhibit portal
<https://github.com/godotengine/godot/pull/108704> so this is no longer necessary.