### PR TITLE
Use --socket=x11, not wayland + fallback-x11

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -43,8 +43,7 @@ build-options:
       accesskit_sdk_path=/app/accesskit-c
 finish-args:
   - --share=ipc
-  - --socket=wayland
-  - --socket=fallback-x11
+  - --socket=x11
   - --share=network
   - --socket=pulseaudio
   - --filesystem=host


### PR DESCRIPTION
In https://github.com/flathub/org.godotengine.Godot/pull/181 I introduced
`--socket=wayland` and deliberately left `--socket=x11` rather than not
`--socket=fallback-x11`. A later commit switched to `--socket=fallback-x11`,
meaning that on Wayland-capable systems Wayland would be used.

Godot upstream still defaults to X11, and as of 4.6.2 there are easy-to-hit
crash bugs in the Wayland backend.

Having `--socket=wayland` and `--socket=x11` allowed the Flatpak to follow the
upstream behaviour, while also using Wayland if the user selects it in the Godot
settings or if X11 is not available, without having to adjust the Flatpak flags.

However, the necessary linter exception to allow this IMO useful behaviour was
removed in
https://github.com/flathub-infra/flatpak-builder-lint/commit/5f45156341547f7c2ecf6c72a51ca5fe4005f5f9.

Revert to plain `--socket=x11`.

Resolves https://github.com/flathub/org.godotengine.Godot/issues/242
