### PR TITLE
Fixing BREAKING change that removed wayland

### DIFF
--- a/org.godotengine.Godot.yaml
+++ b/org.godotengine.Godot.yaml
@@ -44,6 +44,7 @@ build-options:
 finish-args:
   - --share=ipc
   - --socket=x11
+  - --socket=wayland
   - --share=network
   - --socket=pulseaudio
   - --filesystem=host


### PR DESCRIPTION
Please read the documentation, and look at the direction we are moving with Linux.
Removing Wayland broke a lot of functionality by default for users, and actively moves against what godot is intending (re: https://godotengine.org/article/hdr-output-arrives-in-godot-4-7/)
Note only Wayland supports HDR.
We are better off accessing both sockets, then fallback.
My proposed change that was improperly implemented before upstream blockers did not remove X11, only added it as fallback. current state breaks Wayland only entirely, forcing X11/XWayland usage and entirely breaking projects relying on HDR.